### PR TITLE
Fix some generic casting issues.

### DIFF
--- a/grox-core-rx/build.gradle
+++ b/grox-core-rx/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-  repositories {
-    jcenter()
-  }
-}
-
 apply plugin: 'java-library'
 apply from: rootProject.file("${quality_gradle_java_file}")
 apply plugin: 'com.github.hierynomus.license'

--- a/grox-core-rx/src/main/java/com/groupon/grox/RxStores.java
+++ b/grox-core-rx/src/main/java/com/groupon/grox/RxStores.java
@@ -39,6 +39,6 @@ public final class RxStores {
     if (store == null) {
       throw new IllegalArgumentException("Store is null");
     }
-    return Observable.create(new StoreOnSubscribe<STATE>(store));
+    return Observable.create(new StoreOnSubscribe<>(store));
   }
 }

--- a/grox-core-rx/src/main/java/com/groupon/grox/StoreOnSubscribe.java
+++ b/grox-core-rx/src/main/java/com/groupon/grox/StoreOnSubscribe.java
@@ -27,9 +27,9 @@ import rx.Subscription;
  * @param <STATE> the class of the the state of the store.
  */
 final class StoreOnSubscribe<STATE> implements Observable.OnSubscribe<STATE> {
-  private final Store store;
+  private final Store<STATE> store;
 
-  StoreOnSubscribe(Store store) {
+  StoreOnSubscribe(Store<STATE> store) {
     this.store = store;
   }
 

--- a/grox-core-rx2/build.gradle
+++ b/grox-core-rx2/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-  repositories {
-    jcenter()
-  }
-}
-
 apply plugin: 'java-library'
 apply from: rootProject.file("${quality_gradle_java_file}")
 apply plugin: 'com.github.hierynomus.license'

--- a/grox-core-rx2/src/main/java/com/groupon/grox/RxStores.java
+++ b/grox-core-rx2/src/main/java/com/groupon/grox/RxStores.java
@@ -39,6 +39,6 @@ public final class RxStores {
     if (store == null) {
       throw new IllegalArgumentException("Store is null");
     }
-    return Observable.create(new StoreOnSubscribe<STATE>(store));
+    return Observable.create(new StoreOnSubscribe<>(store));
   }
 }

--- a/grox-core-rx2/src/main/java/com/groupon/grox/StoreOnSubscribe.java
+++ b/grox-core-rx2/src/main/java/com/groupon/grox/StoreOnSubscribe.java
@@ -27,9 +27,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @param <STATE> the class of the the state of the store.
  */
 final class StoreOnSubscribe<STATE> implements ObservableOnSubscribe<STATE> {
-  private final Store store;
+  private final Store<STATE> store;
 
-  StoreOnSubscribe(Store store) {
+  StoreOnSubscribe(Store<STATE> store) {
     this.store = store;
   }
 

--- a/grox-core/src/main/java/com/groupon/grox/RealMiddlewareChain.java
+++ b/grox-core/src/main/java/com/groupon/grox/RealMiddlewareChain.java
@@ -56,7 +56,7 @@ final class RealMiddlewareChain<STATE> implements Store.Middleware.Chain<STATE> 
   }
 
   @Override
-  public void proceed(Action action) {
+  public void proceed(Action<STATE> action) {
     if (index >= middlewares.size()) {
       throw new AssertionError();
     }

--- a/grox-core/src/main/java/com/groupon/grox/Store.java
+++ b/grox-core/src/main/java/com/groupon/grox/Store.java
@@ -196,10 +196,7 @@ public class Store<STATE> {
     @Override
     public void intercept(Chain<STATE> chain) {
       chain.proceed(chain.action());
-      for (Iterator<StateChangeListener<STATE>> iterator = stateChangeListeners.iterator();
-          iterator.hasNext();
-          ) {
-        StateChangeListener<STATE> stateChangeListener = iterator.next();
+      for (StateChangeListener<STATE> stateChangeListener : stateChangeListeners) {
         stateChangeListener.onStateChanged(state);
       }
     }


### PR DESCRIPTION
Remove jcenter from subproject build scripts. This is redundant since it
is already declared in the root.