### PR TITLE
Remove some warnings due to generics

### DIFF
--- a/grox-core-rx/src/test/java/com/groupon/grox/RxStoresTest.java
+++ b/grox-core-rx/src/test/java/com/groupon/grox/RxStoresTest.java
@@ -33,7 +33,7 @@ public class RxStoresTest {
   public void states_should_observeInitialState() {
     //GIVEN
     Store<Integer> store = new Store<>(0);
-    TestSubscriber testSubscriber = new TestSubscriber();
+    TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
 
     //WHEN
     states(store).subscribe(testSubscriber);

--- a/grox-core/src/main/java/com/groupon/grox/Store.java
+++ b/grox-core/src/main/java/com/groupon/grox/Store.java
@@ -52,21 +52,11 @@ public class Store<STATE> {
   /** Internal state flag raised and lowered when dispatching. */
   private final AtomicBoolean isDispatching = new AtomicBoolean(false);
 
-  public Store(STATE initialState) {
-    this.state = initialState;
-    this.middlewares.add(new NotifySubscribersMiddleware());
-    this.middlewares.add(new CallReducerMiddleware());
-  }
-
   @SafeVarargs
-  public Store(STATE initialState, Middleware<STATE> first, Middleware<STATE>... others) {
-    if (first == null) {
-      throw new IllegalArgumentException("The first middleware can't be null.");
-    }
+  public Store(STATE initialState, Middleware<STATE>... middlewares) {
     this.state = initialState;
     this.middlewares.add(new NotifySubscribersMiddleware());
-    this.middlewares.add(first);
-    this.middlewares.addAll(asList(others));
+    this.middlewares.addAll(asList(middlewares));
     this.middlewares.add(new CallReducerMiddleware());
   }
 
@@ -145,7 +135,7 @@ public class Store<STATE> {
      * call {@link Action#newState(Object)}. </br> Hence, a middle ware can do things before the
      * rest of the middle wares are executed (and the action is executed) and after the rest of the
      * middle wares are executed (and the action is executed). </br> Middle wares are added to a
-     * store at construction time, see {@link #Store(Object, Middleware, Middleware[])} .
+     * store at construction time, see {@link #Store(Object, Middleware[])} .
      *
      * @param chain the chain of all middle wares for the store associated to this middleware.
      */
@@ -154,7 +144,7 @@ public class Store<STATE> {
     /**
      * Represents the linked list of all middle wares int the store. The order of the middle ware
      * corresponds to the order in which the middle wares are passed to the store at construction
-     * time. See {@link #Store(Object, Middleware, Middleware[])}
+     * time. See {@link #Store(Object, Middleware[])}
      *
      * @param <STATE> the class of the state.
      */

--- a/grox-sample-rx/src/main/java/com/groupon/grox/sample/MainActivity.java
+++ b/grox-sample-rx/src/main/java/com/groupon/grox/sample/MainActivity.java
@@ -21,6 +21,7 @@ import static rx.android.schedulers.AndroidSchedulers.mainThread;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 import com.groupon.grox.Store;
@@ -39,13 +40,17 @@ public class MainActivity extends AppCompatActivity {
     setContentView(R.layout.activity_main);
     final View button = findViewById(R.id.button);
 
-    subscription.add(states(store).observeOn(mainThread()).subscribe(this::updateUI));
+    subscription.add(states(store).observeOn(mainThread()).subscribe(this::updateUI, this::doLog));
 
     subscription.add(
         clicks(button)
             .map(click -> new RefreshColorCommand())
             .flatMap(Command::actions)
-            .subscribe(store::dispatch));
+            .subscribe(store::dispatch, this::doLog));
+  }
+
+  private void doLog(Throwable throwable) {
+    Log.d("Grox", "An error occurred in a Grox chain.", throwable);
   }
 
   private void updateUI(State newState) {

--- a/grox-sample-rx2/src/main/java/com/groupon/grox/sample/MainActivity.java
+++ b/grox-sample-rx2/src/main/java/com/groupon/grox/sample/MainActivity.java
@@ -21,6 +21,7 @@ import static io.reactivex.android.schedulers.AndroidSchedulers.mainThread;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 import com.groupon.grox.Store;
@@ -39,13 +40,14 @@ public class MainActivity extends AppCompatActivity {
     setContentView(R.layout.activity_main);
     final View button = findViewById(R.id.button);
 
-    compositeDisposable.add(states(store).observeOn(mainThread()).subscribe(this::updateUI));
+    compositeDisposable.add(
+        states(store).observeOn(mainThread()).subscribe(this::updateUI, this::doLog));
 
     compositeDisposable.add(
         clicks(button)
             .map(click -> new RefreshColorCommand())
             .flatMap(Command::actions)
-            .subscribe(store::dispatch));
+            .subscribe(store::dispatch, this::doLog));
   }
 
   private void updateUI(State newState) {
@@ -59,6 +61,10 @@ public class MainActivity extends AppCompatActivity {
     } else if (newState.color != State.INVALID_COLOR) {
       label.setBackgroundColor(newState.color);
     }
+  }
+
+  private void doLog(Throwable throwable) {
+    Log.d("Grox", "An error occurred in a Grox chain.", throwable);
   }
 
   @Override


### PR DESCRIPTION
Following up #30, this PR fixes a few warnings in code due to generics or varargs.