### PR TITLE
Clean up the code in Rx2.

### DIFF
--- a/grox-core-rx2/src/test/java/com/groupon/grox/RxStoresTest.java
+++ b/grox-core-rx2/src/test/java/com/groupon/grox/RxStoresTest.java
@@ -33,7 +33,7 @@ public class RxStoresTest {
   public void states_should_observeInitialState() {
     //GIVEN
     Store<Integer> store = new Store<>(0);
-    TestObserver testSubscriber = new TestObserver();
+    TestObserver<Integer> testSubscriber = new TestObserver<>();
 
     //WHEN
     states(store).subscribe(testSubscriber);
@@ -47,7 +47,7 @@ public class RxStoresTest {
   public void states_should_observeStateChanges() {
     //GIVEN
     Store<Integer> store = new Store<>(0);
-    TestObserver testSubscriber = new TestObserver();
+    TestObserver<Integer> testSubscriber = new TestObserver<>();
     states(store).subscribe(testSubscriber);
 
     //WHEN
@@ -62,7 +62,7 @@ public class RxStoresTest {
   public void states_should_stopObservingStateChanges() {
     //GIVEN
     Store<Integer> store = new Store<>(0);
-    TestObserver testSubscriber = new TestObserver();
+    TestObserver<Integer> testSubscriber = new TestObserver<>();
     states(store).subscribe(testSubscriber);
 
     //WHEN


### PR DESCRIPTION
RxJava2 provides APIs to unsubscribe from the source when the observable
is disposed.

RxJava2's ObservableEmitter checks internally if the observables is
disposed so there is no need to do a redundant check.