### PR TITLE
Clean up the code in Rx1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   ext.deps = [findbugs       : 'com.google.code.findbugs:jsr305:2.0.1',
               junit          : 'junit:junit:4.12',
               easymock       : 'org.easymock:easymock:3.4',
-              rxjava         : 'io.reactivex:rxjava:1.2.7',
+              rxjava         : 'io.reactivex:rxjava:1.3.4',
               rxjava2        : 'io.reactivex.rxjava2:rxjava:2.1.6',
               rxbinding      : 'com.jakewharton.rxbinding:rxbinding:1.0.1',
               rxbinding2     : 'com.jakewharton.rxbinding2:rxbinding:2.0.0',

--- a/grox-core-rx/src/main/java/com/groupon/grox/RxStores.java
+++ b/grox-core-rx/src/main/java/com/groupon/grox/RxStores.java
@@ -15,6 +15,7 @@
  */
 package com.groupon.grox;
 
+import rx.Emitter.BackpressureMode;
 import rx.Observable;
 
 /** A helper class to make it easier to use {@link Store} with Rx 1. */
@@ -39,6 +40,6 @@ public final class RxStores {
     if (store == null) {
       throw new IllegalArgumentException("Store is null");
     }
-    return Observable.create(new StoreOnSubscribe<>(store));
+    return Observable.create(new StoreOnSubscribe<>(store), BackpressureMode.ERROR);
   }
 }

--- a/grox-core-rx/src/test/java/com/groupon/grox/RxStoresTest.java
+++ b/grox-core-rx/src/test/java/com/groupon/grox/RxStoresTest.java
@@ -47,7 +47,7 @@ public class RxStoresTest {
   public void states_should_observeStateChanges() {
     //GIVEN
     Store<Integer> store = new Store<>(0);
-    TestSubscriber testSubscriber = new TestSubscriber();
+    TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
     states(store).subscribe(testSubscriber);
 
     //WHEN
@@ -62,7 +62,7 @@ public class RxStoresTest {
   public void states_should_stopObservingStateChanges() {
     //GIVEN
     Store<Integer> store = new Store<>(0);
-    TestSubscriber testSubscriber = new TestSubscriber();
+    TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
     final Subscription subscription = states(store).subscribe(testSubscriber);
 
     //WHEN


### PR DESCRIPTION
Remove usage of the deprecated Observable.create() in favor of the
non-deprecated version.

This greatly simplifies the code.
Since backpressure was previously not handled, backpressure will now
throw an error if t happens.