### PR TITLE
Change 'rxjava' dependencies to be 'api' instead of 'implementation'

### DIFF
--- a/grox-commands-rx/build.gradle
+++ b/grox-commands-rx/build.gradle
@@ -5,8 +5,8 @@ apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 dependencies {
   api project(':grox-core')
+  api deps.rxjava
   compileOnly deps.findbugs
-  implementation deps.rxjava
 
   testCompile deps.junit
   testCompile deps.easymock

--- a/grox-commands-rx2/build.gradle
+++ b/grox-commands-rx2/build.gradle
@@ -5,8 +5,8 @@ apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 dependencies {
   api project(':grox-core')
+  api deps.rxjava2
   compileOnly deps.findbugs
-  implementation deps.rxjava2
 
   testImplementation deps.junit
   testImplementation deps.easymock

--- a/grox-core-rx/build.gradle
+++ b/grox-core-rx/build.gradle
@@ -5,8 +5,8 @@ apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 dependencies {
   api (project(':grox-core'))
+  api deps.rxjava
   compileOnly deps.findbugs
-  implementation deps.rxjava
 
   testImplementation deps.junit
   testImplementation deps.easymock

--- a/grox-core-rx2/build.gradle
+++ b/grox-core-rx2/build.gradle
@@ -5,8 +5,8 @@ apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 dependencies {
   api (project(':grox-core'))
+  api deps.rxjava2
   compileOnly deps.findbugs
-  implementation deps.rxjava2
 
   testImplementation deps.junit
   testImplementation deps.easymock


### PR DESCRIPTION
According to Gradle's documentation about [Recognizing API and implementation dependencies](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_recognizing_dependencies), an API dependency includes:

* _types used in super classes or interfaces_
* _types used in public method parameters, including generic parameter types (where public is something that is visible to compilers. I.e. , public, protected and package private members in the Java world)_


All the `-rx` and `-rx2` subprojects define **RxJava** as an `implementation` dependency. However, these subprojects expose public APIs that return or accept **RxJava** objects, like `Observable`, `Emitter`, `Action1`, etc. Therefore these dependencies should be defined as `api`.
