### PR TITLE
Move Rx classes under version namespace to prevent collisions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     # https://github.com/travis-ci/travis-ci/issues/5036
     - tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-27.0.3
+    - android-27
     - extra-android-m2repository
 
 jdk:

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply from: rootProject.file('config/hooks/install-git-hooks.gradle')
 
 buildscript {
   ext.versions = ['minSdk'        : 14,
-                  'compileSdk'    : 25,
-                  'buildTools'    : '26.0.2',
+                  'compileSdk'    : 27,
+                  'buildTools'    : '27.0.3',
 
                   'supportLibrary': '25.3.1',]
 
@@ -27,7 +27,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
+    classpath 'com.android.tools.build:gradle:3.1.2'
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0"
   }
 }

--- a/config/quality_android.gradle
+++ b/config/quality_android.gradle
@@ -1,6 +1,12 @@
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 
+android {
+  lintOptions {
+    disable "GoogleAppIndexingWarning", "AllowBackup"
+  }
+}
+
 task findbugs(type: FindBugs) {
   ignoreFailures = false
   effort = "max"
@@ -40,4 +46,4 @@ task pmd(type: Pmd) {
   }
 }
 
-check.dependsOn 'findbugs', 'pmd'
+check.dependsOn 'assemble', 'findbugs', 'pmd'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 08 15:19:29 PST 2017
+#Fri May 25 15:36:16 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/grox-core-rx/src/main/java/com/groupon/grox/rxjava1/RxStores.java
+++ b/grox-core-rx/src/main/java/com/groupon/grox/rxjava1/RxStores.java
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.groupon.grox;
+package com.groupon.grox.rxjava1;
 
-import io.reactivex.Observable;
+import com.groupon.grox.Store;
+import rx.Emitter.BackpressureMode;
+import rx.Observable;
 
-/** A helper class to make it easier to use {@link Store} with Rx 2. */
+/** A helper class to make it easier to use {@link Store} with Rx 1. */
 public final class RxStores {
 
   private RxStores() {
@@ -39,6 +41,6 @@ public final class RxStores {
     if (store == null) {
       throw new IllegalArgumentException("Store is null");
     }
-    return Observable.create(new StoreOnSubscribe<>(store));
+    return Observable.create(new StoreOnSubscribe<>(store), BackpressureMode.ERROR);
   }
 }

--- a/grox-core-rx/src/main/java/com/groupon/grox/rxjava1/StoreOnSubscribe.java
+++ b/grox-core-rx/src/main/java/com/groupon/grox/rxjava1/StoreOnSubscribe.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.groupon.grox;
+package com.groupon.grox.rxjava1;
 
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Cancellable;
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.groupon.grox.Store;
+import rx.Emitter;
+import rx.functions.Action1;
+import rx.functions.Cancellable;
 
 /**
- * Internal subscriber to a store's observable. It basically allows to unsubscribe from the store
- * when the observable is disposed.
+ * Internal subscriber to a store's obersvable. It basically allows to unsubscribe from the store
+ * when the observable is unsubscribed from.
  *
  * @param <STATE> the class of the the state of the store.
  */
-final class StoreOnSubscribe<STATE> implements ObservableOnSubscribe<STATE> {
+final class StoreOnSubscribe<STATE> implements Action1<Emitter<STATE>> {
   private final Store<STATE> store;
 
   StoreOnSubscribe(Store<STATE> store) {
@@ -35,12 +34,14 @@ final class StoreOnSubscribe<STATE> implements ObservableOnSubscribe<STATE> {
   }
 
   @Override
-  public void subscribe(ObservableEmitter<STATE> emitter) throws Exception {
+  public void call(Emitter<STATE> stateEmitter) {
 
     //the internal listener to the store.
     Store.StateChangeListener<STATE> listener =
-        emitter::onNext;
-    emitter.setCancellable(() -> store.unsubscribe(listener));
+        stateEmitter::onNext;
+
+    stateEmitter.setCancellation(() -> store.unsubscribe(listener));
+
     store.subscribe(listener);
   }
 }

--- a/grox-core-rx2/src/main/java/com/groupon/grox/rxjava2/RxStores.java
+++ b/grox-core-rx2/src/main/java/com/groupon/grox/rxjava2/RxStores.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.groupon.grox;
+package com.groupon.grox.rxjava2;
 
-import rx.Emitter.BackpressureMode;
-import rx.Observable;
+import com.groupon.grox.Store;
+import io.reactivex.Observable;
 
-/** A helper class to make it easier to use {@link Store} with Rx 1. */
+/** A helper class to make it easier to use {@link Store} with Rx 2. */
 public final class RxStores {
 
   private RxStores() {
@@ -40,6 +40,6 @@ public final class RxStores {
     if (store == null) {
       throw new IllegalArgumentException("Store is null");
     }
-    return Observable.create(new StoreOnSubscribe<>(store), BackpressureMode.ERROR);
+    return Observable.create(new StoreOnSubscribe<>(store));
   }
 }

--- a/grox-core-rx2/src/main/java/com/groupon/grox/rxjava2/StoreOnSubscribe.java
+++ b/grox-core-rx2/src/main/java/com/groupon/grox/rxjava2/StoreOnSubscribe.java
@@ -13,19 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.groupon.grox;
+package com.groupon.grox.rxjava2;
 
-import rx.Emitter;
-import rx.functions.Action1;
-import rx.functions.Cancellable;
+import com.groupon.grox.Store;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Cancellable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Internal subscriber to a store's obersvable. It basically allows to unsubscribe from the store
- * when the observable is unsubscribed from.
+ * Internal subscriber to a store's observable. It basically allows to unsubscribe from the store
+ * when the observable is disposed.
  *
  * @param <STATE> the class of the the state of the store.
  */
-final class StoreOnSubscribe<STATE> implements Action1<Emitter<STATE>> {
+final class StoreOnSubscribe<STATE> implements ObservableOnSubscribe<STATE> {
   private final Store<STATE> store;
 
   StoreOnSubscribe(Store<STATE> store) {
@@ -33,14 +36,12 @@ final class StoreOnSubscribe<STATE> implements Action1<Emitter<STATE>> {
   }
 
   @Override
-  public void call(Emitter<STATE> stateEmitter) {
+  public void subscribe(ObservableEmitter<STATE> emitter) throws Exception {
 
     //the internal listener to the store.
     Store.StateChangeListener<STATE> listener =
-        stateEmitter::onNext;
-
-    stateEmitter.setCancellation(() -> store.unsubscribe(listener));
-
+        emitter::onNext;
+    emitter.setCancellable(() -> store.unsubscribe(listener));
     store.subscribe(listener);
   }
 }

--- a/grox-sample-rx/build.gradle
+++ b/grox-sample-rx/build.gradle
@@ -2,11 +2,16 @@ apply plugin: 'com.android.application'
 apply from: rootProject.file("${quality_gradle_android_file}")
 apply plugin: 'com.github.hierynomus.license'
 
+repositories {
+  google()
+}
+
 android {
   compileSdkVersion versions.compileSdk
   buildToolsVersion versions.buildTools
   defaultConfig {
     minSdkVersion versions.minSdk
+    targetSdkVersion versions.compileSdk
   }
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/grox-sample-rx/src/main/java/com/groupon/grox/sample/MainActivity.java
+++ b/grox-sample-rx/src/main/java/com/groupon/grox/sample/MainActivity.java
@@ -15,7 +15,7 @@
  */
 package com.groupon.grox.sample;
 
-import static com.groupon.grox.RxStores.states;
+import static com.groupon.grox.rxjava1.RxStores.states;
 import static com.jakewharton.rxbinding.view.RxView.clicks;
 import static rx.android.schedulers.AndroidSchedulers.mainThread;
 

--- a/grox-sample-rx/src/main/res/layout/activity_main.xml
+++ b/grox-sample-rx/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
       android:id="@+id/button"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="Change color"/>
+      android:text="@string/change_color"/>
 
   <TextView
       android:id="@+id/label"

--- a/grox-sample-rx/src/main/res/values/strings.xml
+++ b/grox-sample-rx/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Grox sample Rx</string>
+    <string name="change_color">Change color</string>
 </resources>

--- a/grox-sample-rx2/build.gradle
+++ b/grox-sample-rx2/build.gradle
@@ -2,11 +2,16 @@ apply plugin: 'com.android.application'
 apply from: rootProject.file("${quality_gradle_android_file}")
 apply plugin: 'com.github.hierynomus.license'
 
+repositories {
+  google()
+}
+
 android {
   compileSdkVersion versions.compileSdk
   buildToolsVersion versions.buildTools
   defaultConfig {
     minSdkVersion versions.minSdk
+    targetSdkVersion versions.compileSdk
   }
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/grox-sample-rx2/src/main/java/com/groupon/grox/sample/MainActivity.java
+++ b/grox-sample-rx2/src/main/java/com/groupon/grox/sample/MainActivity.java
@@ -15,7 +15,7 @@
  */
 package com.groupon.grox.sample;
 
-import static com.groupon.grox.RxStores.states;
+import static com.groupon.grox.rxjava2.RxStores.states;
 import static com.jakewharton.rxbinding2.view.RxView.clicks;
 import static io.reactivex.android.schedulers.AndroidSchedulers.mainThread;
 

--- a/grox-sample-rx2/src/main/res/layout/activity_main.xml
+++ b/grox-sample-rx2/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
       android:id="@+id/button"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="Change color"/>
+      android:text="@string/change_color"/>
 
   <TextView
       android:id="@+id/label"

--- a/grox-sample-rx2/src/main/res/values/strings.xml
+++ b/grox-sample-rx2/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Grox sample Rx2</string>
+    <string name="change_color">Change color</string>
 </resources>

--- a/grox-sample/build.gradle
+++ b/grox-sample/build.gradle
@@ -2,11 +2,16 @@ apply plugin: 'com.android.application'
 apply from: rootProject.file("${quality_gradle_android_file}")
 apply plugin: 'com.github.hierynomus.license'
 
+repositories {
+  google()
+}
+
 android {
   compileSdkVersion versions.compileSdk
   buildToolsVersion versions.buildTools
   defaultConfig {
     minSdkVersion versions.minSdk
+    targetSdkVersion versions.compileSdk
   }
 
   lintOptions {

--- a/grox-sample/src/main/res/layout/activity_main.xml
+++ b/grox-sample/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
       android:id="@+id/button"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="Change color"/>
+      android:text="@string/change_color"/>
 
   <TextView
       android:id="@+id/label"

--- a/grox-sample/src/main/res/values/strings.xml
+++ b/grox-sample/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Grox sample</string>
+    <string name="change_color">Change color</string>
 </resources>


### PR DESCRIPTION
For Issue #42

Also updates Gradle and related Android plugin; fixes linter errors on sample projects.